### PR TITLE
support as_emld.raw, closes #19, #20

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,6 +3,7 @@
 S3method(as_emld,character)
 S3method(as_emld,json)
 S3method(as_emld,list)
+S3method(as_emld,raw)
 S3method(as_emld,xml_document)
 S3method(as_json,emld)
 S3method(as_json,list)

--- a/man/as_emld.Rd
+++ b/man/as_emld.Rd
@@ -4,10 +4,16 @@
 \alias{as_emld}
 \title{as_emld}
 \usage{
-as_emld(x)
+as_emld(x, from = c("guess", "xml", "json", "list"))
 }
 \arguments{
 \item{x}{path to an EML file}
+
+\item{from}{explicit type for the input format. By default, will
+attempt to guess the format, but it always safer to specify the
+input format. This is essential for literal text strings or raw
+vectors where the type cannot be guessed by the R object class
+or file extension of the input.}
 }
 \description{
 Parse an EML file into an emld object.

--- a/tests/testthat/test-as_emld.R
+++ b/tests/testthat/test-as_emld.R
@@ -62,3 +62,17 @@ test_that("we can parse repeated name elements", {
   expect_is(json, "json")
   })
 
+
+test_that("raw files can be parsed", {
+  emld <- as_emld(ex)
+
+  ex_char <- paste(readLines(ex), collapse = "\n")
+  # potentially test for char formats here. currently doesn't work (converts to list of 1 instead of 6)
+  # emld_char <- as_emld(ex_char)
+  # expect_equal(emld, emld_char)
+
+  ex_raw <- charToRaw(ex_char)
+  emld_raw <- as_emld(ex_raw, "xml")
+  expect_equal(emld, emld_raw)
+  expect_warning(emld_raw <- as_emld(ex_raw), "assuming raw vector is xml")
+})


### PR DESCRIPTION
@isteves Here's a quick re-take on your PR that should be compatible with JSON and XML raw vectors by being explicit about the input type with an additional `from` argument.  If no type is given, will attempt `xml` parsing with a warning. 